### PR TITLE
fix(ssr):filtering HTTP objects

### DIFF
--- a/lib/hypernova/controller_helpers.rb
+++ b/lib/hypernova/controller_helpers.rb
@@ -71,7 +71,7 @@ module Hypernova
     RENDER_STATUS_REGEX = /data-hypernova-cache/
 
     def render_result_without_cache
-      if defined? response
+      if defined?(response) && response.is_a?(ActiveDispatch::Response)  
         response.headers['Cache-Control'] = 'no-store'
       end
     end


### PR DESCRIPTION
解决：当用户发布博客时，后端queue job会观察用户的的博客是否有人订阅，如果有人订阅，将调用hypernova并将模版发送通过邮件发送给用户。但此时是后端的一个queue job对象调用的hypernova，并不是一个http对象。